### PR TITLE
Fix "An error occurred while installing ruby-2.2.2" on Heroku deploy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 if ENV['HEROKU_APP_NAME']
-  ruby '2.2.2'
+  ruby '2.6.2'
 end
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'


### PR DESCRIPTION
I tried installing using the instructions found in https://doc.locomotivecms.com/v4.0/docs/heroku .

It seems it would be an easy change to switch ruby version to a version that Heroku supports: https://devcenter.heroku.com/articles/ruby-support#supported-runtimes

Heroku returns this log:

-----> Ruby app detected
-----> Compiling Ruby/Rails
Command: 'set -o pipefail; curl -L --fail --retry 5 --retry-delay 1 --connect-timeout 3 --max-time 30 https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-18/ruby-2.2.2.tgz -s -o - | tar zxf - ' failed on attempt 1 of 3.
Command: 'set -o pipefail; curl -L --fail --retry 5 --retry-delay 1 --connect-timeout 3 --max-time 30 https://s3-external-1.amazonaws.com/heroku-buildpack-ruby/heroku-18/ruby-2.2.2.tgz -s -o - | tar zxf - ' failed on attempt 2 of 3.
!
! An error occurred while installing ruby-2.2.2
!
! This version of Ruby is not available on Heroku-18. The minimum supported version
! of Ruby on the Heroku-18 stack can found at:
!
! https://devcenter.heroku.com/articles/ruby-support#supported-runtimes
!
! Push rejected, failed to compile Ruby app.
! Push failed